### PR TITLE
fix applyTransformOnSuccess for py3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- More py3 test and functionality fixes.
+  [pbauer, thet]
 
 
 2.0.0 (2018-06-20)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,8 +31,8 @@ New features:
 
 Bug fixes:
 
-- More fixes for Python 2 / 3 compatibility
-  [pbauer]
+- More fixes for Python 2 / 3 compatibility.
+  [pbauer, thet]
 
 
 1.2.2 (2018-02-11)

--- a/plone/transformchain/tests.py
+++ b/plone/transformchain/tests.py
@@ -217,14 +217,14 @@ class TestTransformChain(unittest.TestCase):
         class Transform1(FauxTransformBase):
 
             def transformIterable(self, result, encoding):
-                return ''.join(result) + ' One'
+                return u''.join(result) + u' One'
 
         class Transform2(FauxTransformBase):
 
             order = 1
 
             def transformUnicode(self, result, encoding):
-                return result.encode(encoding) + ' Two'.encode(encoding)
+                return result.encode(encoding) + u' Two'.encode(encoding)
 
         class Transform3(FauxTransformBase):
 

--- a/plone/transformchain/tests.py
+++ b/plone/transformchain/tests.py
@@ -15,6 +15,7 @@ from ZPublisher.Iterators import filestream_iterator
 
 import os
 import pkg_resources
+import six
 import tempfile
 import unittest
 
@@ -108,7 +109,7 @@ class TestTransformChain(unittest.TestCase):
         class Transform1(FauxTransformBase):
 
             def transformBytes(self, result, encoding):
-                return result + ' transformed'
+                return result + b' transformed'
 
             def transformUnicode(self, result, encoding):
                 return result + u' transformed'
@@ -133,7 +134,7 @@ class TestTransformChain(unittest.TestCase):
             order = 0
 
             def transformBytes(self, result, encoding):
-                return result + ' transformed'
+                return result + b' transformed'
 
             def transformUnicode(self, result, encoding):
                 return result + u' transformed'
@@ -160,24 +161,24 @@ class TestTransformChain(unittest.TestCase):
         new_result = self.t(request, result, 'utf8')
         self.assertEqual(None, new_result)
 
-    def test_transform_string(self):
+    def test_transform_bytes(self):
 
         class Transform1(FauxTransformBase):
 
             def transformBytes(self, result, encoding):
-                return result + ' One'
+                return result + b' One'
 
         provideAdapter(Transform1, name=u'test.one')
 
         published = FauxPublished()
         request = FauxRequest(published)
-        result = 'Blah'
+        result = b'Blah'
         encoding = 'utf-8'
 
         new_result = self.t(request, result, encoding)
-        self.assertEqual('Blah One', new_result)
+        self.assertEqual(b'Blah One', new_result)
 
-    def test_transform_unicode(self):
+    def test_transform_text(self):
 
         class Transform1(FauxTransformBase):
 
@@ -216,14 +217,14 @@ class TestTransformChain(unittest.TestCase):
         class Transform1(FauxTransformBase):
 
             def transformIterable(self, result, encoding):
-                return u''.join(result) + u' One'
+                return ''.join(result) + ' One'
 
         class Transform2(FauxTransformBase):
 
             order = 1
 
             def transformUnicode(self, result, encoding):
-                return result.encode(encoding) + ' Two'
+                return result.encode(encoding) + ' Two'.encode(encoding)
 
         class Transform3(FauxTransformBase):
 
@@ -264,10 +265,10 @@ class TestTransformChain(unittest.TestCase):
         class Transform1(FauxTransformBase):
 
             def transformBytes(self, result, encoding):
-                return 'One'
+                return b'One'
 
             def transformUnicode(self, result, encoding):
-                return 'One'
+                return u'One'
 
             def transformIterable(self, result, encoding):
                 return 'One'
@@ -280,7 +281,7 @@ class TestTransformChain(unittest.TestCase):
             order = 2
 
             def transformBytes(self, result, encoding):
-                return result + ' three'
+                return result + b' three'
 
             def transformUnicode(self, result, encoding):
                 return result + u' three'
@@ -307,7 +308,7 @@ class TestTransformChain(unittest.TestCase):
             order = 100
 
             def transformBytes(self, result, encoding):
-                return result + ' One'
+                return result + b' One'
 
             def transformUnicode(self, result, encoding):
                 return result + u' One'
@@ -320,7 +321,7 @@ class TestTransformChain(unittest.TestCase):
             order = -100
 
             def transformBytes(self, result, encoding):
-                return result + ' Two'
+                return result + b' Two'
 
             def transformUnicode(self, result, encoding):
                 return result + u' Two'
@@ -333,7 +334,7 @@ class TestTransformChain(unittest.TestCase):
             order = 101
 
             def transformBytes(self, result, encoding):
-                return result + ' Three'
+                return result + b' Three'
 
             def transformUnicode(self, result, encoding):
                 return result + u' Three'
@@ -360,7 +361,7 @@ class TestTransformChain(unittest.TestCase):
             order = 100
 
             def transformBytes(self, result, encoding):
-                return result + ' One'
+                return result + b' One'
 
             def transformUnicode(self, result, encoding):
                 return result + u' One'
@@ -373,7 +374,7 @@ class TestTransformChain(unittest.TestCase):
             order = -100
 
             def transformBytes(self, result, encoding):
-                return result + ' Two'
+                return result + b' Two'
 
             def transformUnicode(self, result, encoding):
                 return result + u' Two'
@@ -388,7 +389,7 @@ class TestTransformChain(unittest.TestCase):
             order = 101
 
             def transformBytes(self, result, encoding):
-                return result + ' Three'
+                return result + b' Three'
 
             def transformUnicode(self, result, encoding):
                 return result + u' Three'
@@ -424,7 +425,7 @@ class TestTransformChain(unittest.TestCase):
             order = 100
 
             def transformBytes(self, result, encoding):
-                return result + ' One'
+                return result + b' One'
 
             def transformUnicode(self, result, encoding):
                 return result + u' One'
@@ -437,7 +438,7 @@ class TestTransformChain(unittest.TestCase):
             order = -100
 
             def transformBytes(self, result, encoding):
-                return result + ' Two'
+                return result + b' Two'
 
             def transformUnicode(self, result, encoding):
                 return result + u' Two'
@@ -452,7 +453,7 @@ class TestTransformChain(unittest.TestCase):
             order = 101
 
             def transformBytes(self, result, encoding):
-                return result + ' Three'
+                return result + b' Three'
 
             def transformUnicode(self, result, encoding):
                 return result + u' Three'
@@ -575,10 +576,10 @@ class TestZPublisherTransforms(unittest.TestCase):
 
         published = FauxPublished()
         request = FauxRequest(published)
-        request.response.headers['content-type'] = 'text/html; charset=dummy'
+        request.response.headers['content-type'] = 'text/html; charset=utf-16'
         applyTransformOnSuccess(FauxPubEvent(request))
 
-        self.assertEqual('dummy', transformer.encoding)
+        self.assertEqual('utf-16', transformer.encoding)
 
     def test_applyTransform_other_encoding_with_header_missing_space(self):
         @implementer(ITransformer)
@@ -593,10 +594,10 @@ class TestZPublisherTransforms(unittest.TestCase):
 
         published = FauxPublished()
         request = FauxRequest(published)
-        request.response.headers['content-type'] = 'text/html;charset=dummy'
+        request.response.headers['content-type'] = 'text/html;charset=utf-16'
         applyTransformOnSuccess(FauxPubEvent(request))
 
-        self.assertEqual('dummy', transformer.encoding)
+        self.assertEqual('utf-16', transformer.encoding)
 
     def test_applyTransform_str(self):
         @implementer(ITransformer)
@@ -682,7 +683,7 @@ class TestZPublisherTransforms(unittest.TestCase):
 
             def __call__(self, request, result, encoding):
                 assert isinstance(result, list)
-                assert isinstance(result[0], str)
+                assert isinstance(result[0], six.binary_type)
                 return 'dummystr'
 
         transformer = FauxTransformer()
@@ -703,7 +704,7 @@ class TestZPublisherTransforms(unittest.TestCase):
 
             def __call__(self, request, result, encoding):
                 assert isinstance(result, list)
-                assert isinstance(result[0], str)
+                assert isinstance(result[0], six.binary_type)
                 return u'dummystr'
 
         transformer = FauxTransformer()

--- a/plone/transformchain/zpublisher.py
+++ b/plone/transformchain/zpublisher.py
@@ -96,10 +96,13 @@ def applyTransformOnSuccess(event):
             or isinstance(transformed, six.binary_type):
         response.setBody(transformed)
     # ... but not with iterables
-    elif hasattr(transformed, '__iter__'):
-        for it in transformed:
-            if isinstance(it, six.binary_type):
-                it = it.decode('utf-8')
+    else:
+        transformed = map(
+            lambda it: it.decode('utf-8')
+            if isinstance(it, six.binary_type)
+            else it,
+            transformed
+        )
         response.setBody(''.join(transformed))
 
 

--- a/plone/transformchain/zpublisher.py
+++ b/plone/transformchain/zpublisher.py
@@ -67,7 +67,7 @@ def applyTransform(request, body=None):
             body = response.getBody()
 
         result = body
-        if isinstance(result, str):
+        if isinstance(result, six.binary_type):
             result = [result]
         elif isinstance(result, six.text_type):
             result = [result.encode(encoding)]

--- a/plone/transformchain/zpublisher.py
+++ b/plone/transformchain/zpublisher.py
@@ -92,11 +92,15 @@ def applyTransformOnSuccess(event):
         response.setBody(transformed)
     # setBody() can deal with byte and unicode strings (and will encode as
     # necessary)...
-    elif isinstance(transformed, six.string_types):
+    elif isinstance(transformed, six.string_types)\
+            or isinstance(transformed, six.binary_type):
         response.setBody(transformed)
     # ... but not with iterables
-    else:
-        response.setBody(b''.join(transformed))
+    elif hasattr(transformed, '__iter__'):
+        for it in transformed:
+            if isinstance(it, six.binary_type):
+                it = it.decode('utf-8')
+        response.setBody(''.join(transformed))
 
 
 @adapter(IPubBeforeAbort)

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,8 @@ setup(
         "License :: OSI Approved :: BSD License",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     keywords='zope2 repoze transform',


### PR DESCRIPTION
Depends on: https://github.com/plone/plone.app.caching/pull/44, specifically on:
https://github.com/plone/plone.app.caching/blob/python3/plone/app/caching/operations/ramcache.py#L47

Merge together:
https://github.com/plone/plone.transformchain/pull/9
https://github.com/plone/plone.app.caching/pull/44

Current Jenkins run:
Plone 4.3 - https://jenkins.plone.org/job/pull-request-4.3/175/
Plone 5.0 - https://jenkins.plone.org/job/pull-request-5.0/529/
Plone 5.1 - https://jenkins.plone.org/job/pull-request-5.1/1203/
Plone 5.2 - https://jenkins.plone.org/job/pull-request-5.2/829/
